### PR TITLE
add rcpt.accept setting to make this act as a rcpt_to plugin

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,6 @@
+# 1.1.0 - 2018-04-23
+
+- #6: add rcpt.accept setting to enable recipient validation for users in whitelists (like an rcpt_to.* plugin)
 
 # 1.0.0 - 201_-__-__
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ Each check can be enabled or disabled in the [check] section of access.ini:
     mail=false
     rcpt=false
 
+    [rcpt]
+    accept=false  (see below)
+
 A custom deny message can be configured for each SMTP phase:
 
     [deny_msg]
@@ -172,6 +175,13 @@ matches are 3x times as slow. When the matches are moved to the end of the
 Based on this observation, reducing the domain name and doing an indexOf
 search of an (even much longer) blacklist is *much* faster than adding lists
 of .\*domain.com entries to the \*\_regex files.
+
+### rcpt accept mode
+
+By default this plugin only rejects recipients on the blacklists, and ignores
+those on the whitelists. Setting `rcpt.accept=true` enables recipient validation
+for users in whitelists, actually accepting mails instead of only blocking
+unwanted recipients.
 
 ### Organizational Domain
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-access",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Haraka plugin that frobnicates email connections",
   "main": "index.js",
   "scripts": {

--- a/test/access.js
+++ b/test/access.js
@@ -349,6 +349,28 @@ exports.rcpt_to_access = {
         this.plugin.list.white.rcpt['user@example.com']=true;
         this.plugin.rcpt_to_access(cb, this.connection, [new Address('<user@example.com>')]);
     },
+    'whitelisted addr, accept enabled': function (test) {
+        test.expect(2);
+        const cb = function (rc) {
+            test.equal(OK, rc);
+            test.ok(this.connection.transaction.results.get('access').pass.length);
+            test.done();
+        }.bind(this);
+        this.plugin.cfg.rcpt.accept=true;
+        this.plugin.list.white.rcpt['user@example.com']=true;
+        this.plugin.rcpt_to_access(cb, this.connection, [new Address('<user@example.com>')]);
+    },
+    'regex whitelisted addr, accept enabled': function (test) {
+        test.expect(2);
+        const cb = function (rc) {
+            test.equal(OK, rc);
+            test.ok(this.connection.transaction.results.get('access').pass.length);
+            test.done();
+        }.bind(this);
+        this.plugin.cfg.rcpt.accept=true;
+        this.plugin.list_re.white.rcpt = new RegExp(`^user@example.com$`, 'i');
+        this.plugin.rcpt_to_access(cb, this.connection, [new Address('<user@example.com>')]);
+    },
     'blacklisted addr': function (test) {
         test.expect(2);
         const cb = function (rc) {


### PR DESCRIPTION
from the updated readme: 

> ### rcpt accept mode
>
> By default this plugin only rejects recipients on the blacklists, and ignores
> those on the whitelists. Setting `rcpt.accept=true` makes it behave like a true
> `rcpt_to.*` plugin, actually accepting mails instead of only blocking unwanted
> recipients.

Tell me what you think, please :)