### PR TITLE
Climate

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ exports.register = function () {
         });
         plugin.register_hook('data_post', 'data_any');
     }
-};
+}
 
 exports.init_config = function () {
     const plugin = this;
@@ -77,7 +77,7 @@ exports.init_config = function () {
             },
         },
     };
-};
+}
 
 exports.load_access_ini = function () {
     const plugin = this;
@@ -119,7 +119,7 @@ exports.load_access_ini = function () {
     if (rdns_cfg && rdns_cfg.general && rdns_cfg.general.deny_msg) {
         plugin.cfg.deny_msg.conn = rdns_cfg.general.deny_msg;
     }
-};
+}
 
 exports.init_lists = function () {
     const plugin = this;
@@ -132,7 +132,7 @@ exports.init_lists = function () {
         black: {},
         white: {},
     };
-};
+}
 
 exports.get_domain = function (hook, connection, params) {
 
@@ -153,7 +153,7 @@ exports.get_domain = function (hook, connection, params) {
             }
     }
     return;
-};
+}
 
 exports.any = function (next, connection, params) {
     const plugin = this;
@@ -214,7 +214,7 @@ exports.any = function (next, connection, params) {
     const pass_msg = hook ? `${hook}:any` : 'any';
     cr.add(plugin, {msg: `unlisted(${pass_msg})` });
     return next();
-};
+}
 
 exports.rdns_access = function (next, connection) {
     const plugin = this;
@@ -277,7 +277,7 @@ exports.rdns_access = function (next, connection) {
 
     connection.results.add(plugin, {msg: 'unlisted(conn)' });
     return next();
-};
+}
 
 exports.helo_access = function (next, connection, helo) {
     const plugin = this;
@@ -291,7 +291,7 @@ exports.helo_access = function (next, connection, helo) {
 
     connection.results.add(plugin, {msg: 'unlisted(helo)' });
     return next();
-};
+}
 
 exports.mail_from_access = function (next, connection, params) {
     const plugin = this;
@@ -335,7 +335,7 @@ exports.mail_from_access = function (next, connection, params) {
 
     connection.transaction.results.add(plugin, {msg: 'unlisted(mail)' });
     return next();
-};
+}
 
 exports.rcpt_to_access = function (next, connection, params) {
     const plugin = this;
@@ -382,7 +382,7 @@ exports.rcpt_to_access = function (next, connection, params) {
 
     connection.transaction.results.add(plugin, {msg: 'unlisted(rcpt)' });
     return next();
-};
+}
 
 exports.data_any = function (next, connection) {
     const plugin = this;
@@ -422,7 +422,7 @@ exports.data_any = function (next, connection) {
 
     connection.results.add(plugin, {msg: 'unlisted(any)' });
     return next();
-};
+}
 
 exports.in_list = function (type, phase, address) {
     const plugin = this;
@@ -432,7 +432,7 @@ exports.in_list = function (type, phase, address) {
     }
     if (plugin.list[type][phase][address.toLowerCase()]) { return true; }
     return false;
-};
+}
 
 exports.in_re_list = function (type, phase, address) {
     const plugin = this;
@@ -445,7 +445,7 @@ exports.in_re_list = function (type, phase, address) {
             `${plugin.cfg.re[type][phase].source}`);
     }
     return plugin.list_re[type][phase].test(address);
-};
+}
 
 exports.in_file = function (file_name, address, connection) {
     const plugin = this;
@@ -454,7 +454,7 @@ exports.in_file = function (file_name, address, connection) {
     connection.logdebug(plugin, `checking ${address} against ${file_name}`);
     return (plugin.config.get(file_name, 'list')
         .indexOf(address) === -1) ? false : true;
-};
+}
 
 exports.in_re_file = function (file_name, address) {
     // Since the helo.checks plugin uses this method, I tested to see how
@@ -467,7 +467,7 @@ exports.in_re_file = function (file_name, address) {
         if (new RegExp('^' + re_list[i] + '$', 'i').test(address)) return true;
     }
     return false;
-};
+}
 
 exports.load_file = function (type, phase) {
     const plugin = this;
@@ -494,7 +494,7 @@ exports.load_file = function (type, phase) {
         listAsHash[list[i].toLowerCase()] = true;
     }
     plugin.list[type][phase] = listAsHash;
-};
+}
 
 exports.load_re_file = function (type, phase) {
     const plugin = this;
@@ -519,7 +519,7 @@ exports.load_re_file = function (type, phase) {
     // compile the regexes at the designated location
     plugin.list_re[type][phase] =
         new RegExp(`^(${regex_list.join('|')})$`, 'i');
-};
+}
 
 exports.load_domain_file = function (type, phase) {
     const plugin = this;
@@ -553,4 +553,4 @@ exports.load_domain_file = function (type, phase) {
         if (!d) { continue; }
         plugin.list[type][phase][d.toLowerCase()] = true;
     }
-};
+}

--- a/test/access.js
+++ b/test/access.js
@@ -13,12 +13,10 @@ const _set_up = function (done) {
     this.plugin.register();
 
     this.connection = fixtures.connection.createConnection();
-    this.connection.transaction = {
-        results: new fixtures.results(this.connection),
-    };
+    this.connection.init_transaction();
 
     done();
-};
+}
 
 exports.in_list = {
     setUp : _set_up,
@@ -90,7 +88,7 @@ exports.in_list = {
         test.equal(false, this.plugin.in_list('black', 'helo', 'matt@non-exist'));
         test.done();
     },
-};
+}
 
 exports.in_re_list = {
     setUp : _set_up,
@@ -154,7 +152,7 @@ exports.in_re_list = {
         test.equal(false, this.plugin.in_re_list('black', 'helo', 'matt@non-exist'));
         test.done();
     },
-};
+}
 
 exports.load_file = {
     setUp : _set_up,
@@ -181,7 +179,7 @@ exports.load_re_file = {
         test.equal(false, this.plugin.in_re_list('white', 'mail', 'LIST@harail.com'));
         test.done();
     },
-};
+}
 
 exports.in_file = {
     setUp : _set_up,
@@ -192,7 +190,7 @@ exports.in_file = {
         test.equal(false, this.plugin.in_file(file, 'matt@harakamail.com', this.connection));
         test.done();
     },
-};
+}
 
 exports.in_re_file = {
     setUp : _set_up,
@@ -204,7 +202,7 @@ exports.in_re_file = {
         test.equal(false, this.plugin.in_re_file(file, 'matt@harkatamale.com'));
         test.done();
     },
-};
+}
 
 exports.rdns_access = {
     setUp : _set_up,
@@ -263,7 +261,7 @@ exports.rdns_access = {
         this.plugin.list_re.black.conn = new RegExp(`^(${black.join('|')})$`, 'i');
         this.plugin.rdns_access(cb, this.connection);
     },
-};
+}
 
 exports.helo_access = {
     setUp : _set_up,
@@ -292,7 +290,7 @@ exports.helo_access = {
         this.plugin.cfg.check.helo=true;
         this.plugin.helo_access(cb, this.connection, 'bad.spam.com');
     },
-};
+}
 
 exports.mail_from_access = {
     setUp : _set_up,
@@ -348,7 +346,7 @@ exports.mail_from_access = {
         this.plugin.list_re.black.mail = new RegExp(`^(${black.join('|')})$`, 'i');
         this.plugin.mail_from_access(cb, this.connection, [new Address('<special@spam.com>')]);
     },
-};
+}
 
 exports.rcpt_to_access = {
     setUp : _set_up,
@@ -430,4 +428,4 @@ exports.rcpt_to_access = {
         this.plugin.list_re.black.rcpt = new RegExp(`^(${black.join('|')})$`, 'i');
         this.plugin.rcpt_to_access(cb, this.connection, [new Address('<special@spam.com>')]);
     },
-};
+}


### PR DESCRIPTION
- remove trailing function semicolons
- DRY: refactor `any_whitelist()` out of `any()`
- test: use newish `this.connection.init_transaction();`