### PR TITLE
register rdns_access on connect_init (vs connect)

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ exports.register = function () {
     for (p in plugin.cfg.re.black) { plugin.load_re_file('black', p); }
 
     if (plugin.cfg.check.conn) {
-        plugin.register_hook('connect', 'rdns_access');
+        plugin.register_hook('connect_init', 'rdns_access');
     }
     if (plugin.cfg.check.helo) {
         plugin.register_hook('helo',    'helo_access');


### PR DESCRIPTION
Run @ connection init.

This plugin defines rdns_access whitelist which is used by other plugins such as fcrdns , but fcrdns hooks on connect_init which would happen *before* this one, so it can't make use of the whitelist/blacklist functionality that this plugin provides