### PR TITLE
run rdns_access on connect_init hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ exports.register = function () {
   }
 
   if (this.cfg.check.conn) {
-    this.register_hook('connect', 'rdns_access')
+    this.register_hook('connect_init', 'rdns_access')
   }
   if (this.cfg.check.helo) {
     this.register_hook('helo', 'helo_access')


### PR DESCRIPTION
fcrdns plugin acts and checks whitelist/blacklist on connect_init, which runs before connect, therefore whitelists/blacklists are ignored by fcrdns

I also made some changes to fcrdns / dns-list plugins to allow dnsbls to whitelist addresses as well in fcrdns. Wanted to ask you if this is something you find interesting for the main project but I didn't know how to contact you otherwise.