### PR TITLE
Fix hook registration for any access.domains

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ exports.register = function () {
 
   if (this.cfg.check.any) {
     this.load_domain_file('domain', 'any')
-    for (const hook in ['connect', 'helo', 'ehlo', 'mail', 'rcpt']) {
+    for (const hook of ['connect', 'helo', 'ehlo', 'mail', 'rcpt']) {
       this.register_hook(hook, 'any')
     }
     this.register_hook('data_post', 'data_any')


### PR DESCRIPTION
The [any](https://github.com/haraka/haraka-plugin-access?tab=readme-ov-file#any) flag with `config/access.domains` does not seem to work as expected because the hook registration for `any` is using ids instead of the actual values.

It would be good to raise an exception in `register_hook` function when a not supported hook is used so we get an error in cases like this instead of quietly failing.