### PR TITLE
fix: tolerate method- and property-style Address.address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+- fix: tolerate both Address APIs; on Haraka <= 3.1.7 (address-rfc2821,
+  .address is a method) the property read yielded a function, so list
+  lookups never matched and in_list threw on .toLowerCase()
 - test: refactored against test-fixtures 1.7.0
 
 ### [1.4.0] - 2026-05-28

--- a/index.js
+++ b/index.js
@@ -152,6 +152,18 @@ exports.get_domain = function (hook, connection, params) {
   return
 }
 
+// The Address objects in params come from the host Haraka:
+// @haraka/email-address (Haraka >= 3.2.0) exposes .address as a string
+// property, address-rfc2821 (Haraka <= 3.1.7) as a method. Reading the
+// method as a property yields the function itself, so no list entry could
+// match and in_list threw on .toLowerCase(). Tolerate both APIs.
+function get_address(a) {
+  if (a == null) return undefined
+  if (typeof a.address === 'function') return a.address()
+  if (a.address != null) return String(a.address)
+  return typeof a.toString === 'function' ? a.toString() : undefined
+}
+
 exports.any_whitelist = function (
   connection,
   hook,
@@ -160,7 +172,7 @@ exports.any_whitelist = function (
   org_domain,
 ) {
   if (['mail', 'rcpt'].includes(hook)) {
-    const email = params?.[0]?.address
+    const email = get_address(params?.[0])
     if (email && this.in_list('domain', 'any', `!${email}`)) return true
   }
 
@@ -279,7 +291,7 @@ exports.rdns_access = function (next, connection) {
 exports.mail_from_access = function (next, connection, params) {
   if (!this.cfg.check.mail) return next()
 
-  const mail_from = params?.[0]?.address
+  const mail_from = get_address(params?.[0])
   if (!mail_from) {
     connection.transaction.results.add(this, {
       skip: 'null sender',
@@ -326,7 +338,7 @@ exports.rcpt_to_access = function (next, connection, params) {
 
   const pass_status = this.cfg.rcpt.accept ? OK : undefined
 
-  const rcpt_to = params?.[0]?.address
+  const rcpt_to = get_address(params?.[0])
 
   // address whitelist checks
   if (!rcpt_to) {
@@ -418,7 +430,7 @@ exports.in_list = function (type, phase, address) {
     this.logdebug(`phase not defined: ${phase}`)
     return false
   }
-  if (!address) return false
+  if (!address || typeof address !== 'string') return false
   if (this.list[type][phase][address.toLowerCase()]) return true
   return false
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "homepage": "https://github.com/haraka/haraka-plugin-access#readme",
   "devDependencies": {
     "@haraka/eslint-config": "~3.0.0",
+    "address-rfc2821": "^2.2.1",
     "haraka-test-fixtures": "^1.7.0"
   },
   "dependencies": {

--- a/test/any.js
+++ b/test/any.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict')
 const { describe, it, before, beforeEach } = require('node:test')
 
 const { Address } = require('@haraka/email-address')
+const { Address: Rfc2821Address } = require('address-rfc2821')
 const {
   assertResult,
   callHook,
@@ -164,6 +165,16 @@ describe('any', () => {
         c.hook = 'mail'
       },
       args: [[new Address('<friend@example.com>')]],
+      expect: { rc: undefined, bucket: 'pass' },
+    },
+    {
+      name: 'whitelist entry !email matches legacy address-rfc2821 objects',
+      setup: (p, c) => {
+        p.list.domain.any['example.com'] = true
+        p.list.domain.any['!friend@example.com'] = true
+        c.hook = 'mail'
+      },
+      args: [[new Rfc2821Address('<friend@example.com>')]],
       expect: { rc: undefined, bucket: 'pass' },
     },
     {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -46,6 +46,14 @@ describe('in_list', () => {
     assert.equal(plugin.in_list('white', 'mail', ''), false)
     assert.equal(plugin.in_list('white', 'mail', undefined), false)
   })
+
+  it('returns false when address is not a string', () => {
+    plugin.list = { white: { mail: { 'matt@exam.ple': true } } }
+    assert.equal(
+      plugin.in_list('white', 'mail', () => {}),
+      false,
+    )
+  })
 })
 
 describe('in_re_list', () => {

--- a/test/mail_from.js
+++ b/test/mail_from.js
@@ -3,6 +3,7 @@
 const assert = require('node:assert/strict')
 const { describe, it, beforeEach } = require('node:test')
 
+const { Address: Rfc2821Address } = require('address-rfc2821')
 const {
   assertResult,
   callHook,
@@ -79,6 +80,17 @@ describe('mail_from_access', () => {
     const { rc } = await callHook(plugin, 'mail_from_access', connection, [])
     assert.equal(rc, undefined)
     assertResult(connection.transaction, 'access', 'skip')
+  })
+
+  it('denies a blacklisted legacy address-rfc2821 sender', async () => {
+    // Haraka <= 3.1.7 passes address-rfc2821 objects, where .address is a
+    // method — reading it as a property broke every list lookup
+    plugin.list.black.mail['list@badmail.com'] = true
+    const { rc } = await callHook(plugin, 'mail_from_access', connection, [
+      new Rfc2821Address('<list@badmail.com>'),
+    ])
+    assert.equal(rc, DENY)
+    assertResult(connection.transaction, 'access', 'fail')
   })
 
   it('returns next() when check.mail is false', async () => {

--- a/test/rcpt_to.js
+++ b/test/rcpt_to.js
@@ -3,6 +3,7 @@
 const assert = require('node:assert/strict')
 const { describe, it, beforeEach } = require('node:test')
 
+const { Address: Rfc2821Address } = require('address-rfc2821')
 const {
   assertResult,
   callHook,
@@ -99,6 +100,17 @@ describe('rcpt_to_access', () => {
     const { rc } = await callHook(plugin, 'rcpt_to_access', connection, [])
     assert.equal(rc, undefined)
     assertResult(connection.transaction, 'access', 'skip')
+  })
+
+  it('denies a blacklisted legacy address-rfc2821 recipient', async () => {
+    // Haraka <= 3.1.7 passes address-rfc2821 objects, where .address is a
+    // method — reading it as a property broke every list lookup
+    plugin.list.black.rcpt['bad@example.com'] = true
+    const { rc } = await callHook(plugin, 'rcpt_to_access', connection, [
+      new Rfc2821Address('<bad@example.com>'),
+    ])
+    assert.equal(rc, DENY)
+    assertResult(connection.transaction, 'access', 'fail')
   })
 
   it('returns next() when check.rcpt is false', async () => {


### PR DESCRIPTION
## Problem

Same root cause as haraka/haraka-plugin-rspamd#59. The Address objects in mail/rcpt hook params come from the host Haraka, and the two parsers in circulation expose `address` differently:

- `@haraka/email-address` (Haraka >= 3.2.0): `address` is a string property
- `address-rfc2821` (every released Haraka <= 3.1.7): `address()` is a method

Since v1.3.0 (#42) the plugin reads `params?.[0]?.address` as a property, so on Haraka <= 3.1.7 it gets the accessor function instead of the address string:

- `mail_from_access` / `rcpt_to_access`: `in_list()` throws `TypeError: address.toLowerCase is not a function` on every check (Haraka logs the plugin exception and continues), so whitelist and blacklist entries are silently never honored
- `any_whitelist`: the `!email` whitelist lookup can never match

The pre-1.3.0 form `params?.[0]?.address?.()` had the mirror-image problem: on Haraka >= 3.2.0 it attempts to call a string (`?.()` only short-circuits on null/undefined, not on non-callables).

## Fix

Extract the bare address through a helper that calls `address` when it is a function and stringifies it otherwise, so the plugin works on either side of the Haraka 3.2.0 parser migration, and guard `in_list` against non-string input so a lookup can never throw. Regression tests exercise all three call sites with real `address-rfc2821` Address objects (added as a devDependency); they fail on the current code and pass with the fix.
